### PR TITLE
containers/ghci-osbuild: add pytest and pytest-cov

### DIFF
--- a/src/pkglists/ghci-osbuild
+++ b/src/pkglists/ghci-osbuild
@@ -20,6 +20,8 @@ python3-docutils
 python3-devel
 python3-jsonschema
 python3-pylint
+python3-pytest
+python3-pytest-cov
 python3-rpm-generators
 python3-rpm-macros
 qemu-img


### PR DESCRIPTION
`pytest` is nicer to use than the standard `unittest` module. The `cov` plugin for it provides coverage support.