### PR TITLE
📦 ghci-osbuild: Include python3-iniparse package

### DIFF
--- a/src/pkglists/ghci-osbuild
+++ b/src/pkglists/ghci-osbuild
@@ -18,6 +18,7 @@ pylint
 python-rpm-macros
 python3-docutils
 python3-devel
+python3-iniparse
 python3-jsonschema
 python3-pylint
 python3-pytest


### PR DESCRIPTION
Add python3-iniparse to the list of packages installed on ghci-osbuild
image. The package is a dependency of a new org.osbuild.rhsm stage.

Related to osbuild/osbuild#555.