### PR TITLE
🏗️ CI: Don't mirror images if they are not pushed

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -144,7 +144,7 @@ jobs:
         fi
 
         MIRROR="false"
-        if [[ "${GITHUB_REPOSITORY}" = "osbuild/containers" ]] ; then
+        if [[ ${PUSH} = "true" && "${GITHUB_REPOSITORY}" = "osbuild/containers" ]] ; then
           MIRROR="true"
         fi
 


### PR DESCRIPTION
Currently, it can happen that while `PUSH` and `RELEASE` environment
variables in the CI environment get set to `false`, the `MIRROR`
variable is still set to `true`. As a result, images will be built as
part of CI, they won't be pushed and released, but they will be tried to
be mirrored on Quay.io and Dodkerhub.

This is especially an issue for CI runs on pull requests, on which the
`PUSH` and `RELEASE` are set to `false`, but mirroring is still
attempted and fails due to missing credentials to respective services.

In fact `MIRROR` is probably always set to `true`, because the
`${GITHUB_REPOSITORY}` is presumably always set to `osbuild/containers`
for pull requests in the upstream repository.

This change ensures that `MIRROR` is set to `true` only if also `PUSH`
is set to `true`.

Signed-off-by: Tomas Hozza <thozza@redhat.com>