### PR TITLE
ghci-osbuild: add python3-boto* libraries

### DIFF
--- a/src/pkglists/ghci-osbuild
+++ b/src/pkglists/ghci-osbuild
@@ -16,6 +16,8 @@ ostree
 policycoreutils
 pylint
 python-rpm-macros
+python3-boto3
+python3-botocore
 python3-docutils
 python3-devel
 python3-iniparse


### PR DESCRIPTION
This is needed for triggering schutzbot, see:
https://github.com/osbuild/osbuild/pull/580