### PR TITLE
ghci-osbuild: add python3-mako package

### DIFF
--- a/src/pkglists/ghci-osbuild
+++ b/src/pkglists/ghci-osbuild
@@ -22,6 +22,7 @@ python3-docutils
 python3-devel
 python3-iniparse
 python3-jsonschema
+python3-mako
 python3-pylint
 python3-pytest
 python3-pytest-cov


### PR DESCRIPTION
This is needed for the boot iso work, where lorax templates are used, which depend on python3-mako. osbuild will gain a utility function to parse and execute those templates and thus we need to have the library so pylint can check the code.