### PR TITLE
osbuild-ci: add python3-pyyaml needed by new cloud-init stage

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -213,6 +213,7 @@ target "virtual-osbuild-ci" {
                         "python3-pylint",
                         "python3-pytest",
                         "python3-pytest-cov",
+                        "python3-pyyaml",
                         "python3-rpm-generators",
                         "python3-rpm-macros",
                         "qemu-img",


### PR DESCRIPTION
Related to https://github.com/osbuild/osbuild/pull/689