### PR TITLE
osbuild-ci: include lvm2 needed for tests

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -196,6 +196,7 @@ target "virtual-osbuild-ci" {
                         "git",
                         "glibc",
                         "iproute",
+                        "lvm2",
                         "make",
                         "nbd",
                         "nbd-cli",


### PR DESCRIPTION
We need the lvm2 utilities in the CI for osbuild to unit tests the `osbuild.utils.lvm2` package.