### PR TITLE
Add new "cloud-tools" container image.

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -74,6 +74,7 @@ group "all-images" {
                 "all-postgres",
                 "all-rpmrepo-ci",
                 "all-rpmrepo-snapshot",
+                "all-cloud-tools",
         ]
 }
 
@@ -296,6 +297,46 @@ target "postgres-13-alpine" {
         ]
         tags = concat(
                 mirror("postgres", "13-alpine", "", OSB_UNIQUEID),
+        )
+}
+
+/*
+ * cloud-tools - Images with Cloud CLI tools
+ *
+ * The following groups and targets build the "cloud tools" images used by
+ * osbuild-composer CI. They build on the official fedora images.
+ */
+
+group "all-cloud-tools" {
+        targets = [
+                "cloud-tools-latest",
+        ]
+}
+
+target "virtual-cloud-tools" {
+        args = {
+                OSB_DNF_PACKAGES = join(",", [
+                        "google-cloud-sdk",
+                        "azure-cli",
+                        "awscli",
+                ]),
+        }
+        dockerfile = "src/images/cloud-tools.Dockerfile"
+        inherits = [
+                "virtual-default",
+                "virtual-platforms",
+        ]
+}
+
+target "cloud-tools-latest" {
+        args = {
+                OSB_FROM = "docker.io/library/fedora:latest",
+        }
+        inherits = [
+                "virtual-cloud-tools",
+        ]
+        tags = concat(
+                mirror("cloud-tools", "latest", "", OSB_UNIQUEID),
         )
 }
 

--- a/src/config/azure-cli.repo
+++ b/src/config/azure-cli.repo
@@ -1,0 +1,6 @@
+[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc

--- a/src/config/google-cloud-sdk.repo
+++ b/src/config/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/src/images/cloud-tools.Dockerfile
+++ b/src/images/cloud-tools.Dockerfile
@@ -1,0 +1,49 @@
+#
+# cloud-tools - Image with Cloud CLI tools
+#
+# This image provides the CLI tools for various cloud providers for use in
+# osbuild-composer CI tests which need to create and delete cloud resources.
+# It is based on Fedora.
+#
+# Arguments:
+#
+#   * OSB_FROM="docker.io/library/fedora:latest"
+#       This controls the host container used as base for the cloud-tools
+#       image.
+#
+#   * OSB_DNF_PACKAGES=""
+#       Specify the packages to install into the container. Separate packages
+#       by comma. By default, no package is pulled in.
+#
+#   * OSB_DNF_GROUPS=""
+#       Specify the package groups to install into the container. Separate
+#       groups by comma. By default, no group is pulled in.
+#
+
+ARG             OSB_FROM="docker.io/library/fedora:latest"
+FROM            "${OSB_FROM}" AS target
+
+#
+# Import our build sources and prepare the target environment. When finished,
+# we drop the build sources again, to keep the target image small.
+#
+
+WORKDIR         /cloud-tools
+COPY            src src
+
+ARG             OSB_DNF_PACKAGES=""
+ARG             OSB_DNF_GROUPS=""
+COPY            src/config/*.repo /etc/yum.repos.d/
+RUN             ./src/scripts/dnf.sh "${OSB_DNF_PACKAGES}" "${OSB_DNF_GROUPS}"
+
+RUN             rm -rf /cloud-tools/src
+
+#
+# Rebuild from scratch to drop all intermediate layers and keep the final image
+# as small as possible. Then setup the entrypoint.
+#
+
+FROM            scratch
+COPY            --from=target . .
+
+WORKDIR         /cloud-tools/workdir


### PR DESCRIPTION
With RHEL-9, the osbuild-composer run into issues related to the CLI
tools provided by each cloud provider. In general they can not be
installed on the RHEL-9 host. This commit adds a new Fedora-based image
with all the necessary CLI tools (for AWS, Azure and GCP), which can be
used in osbuild-composer CI tests to interact with the cloud-provider's
API.

Signed-off-by: Tomas Hozza <thozza@redhat.com>