### PR TITLE
images/osbuild-ci: add `sfdisk` package

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -224,6 +224,7 @@ target "virtual-osbuild-ci" {
                         "rpm-build",
                         "rpm-ostree",
                         "rpmdevtools",
+                        "sfdisk",
                         "systemd",
                         "systemd-container",
                         "tar",


### PR DESCRIPTION
Needed by osbuild test for the `org.osbuild.parted` stage to read and check the partition table.