### PR TITLE
osbuild-ci: include cryptsetup needed for tests

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -189,6 +189,7 @@ target "virtual-osbuild-ci" {
                         "bash",
                         "bubblewrap",
                         "coreutils",
+                        "cryptsetup",
                         "curl",
                         "dnf",
                         "dnf-plugins-core",


### PR DESCRIPTION
We need the cryptsetup packaget in the CI for osbuild to tests the `org.osbuild.luks2.format` stage.