### PR TITLE
Add pacman to the CI container

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -203,6 +203,7 @@ target "virtual-osbuild-ci" {
                         "nbd",
                         "nbd-cli",
                         "ostree",
+                        "pacman",
                         "policycoreutils",
                         "pylint",
                         "python-rpm-macros",


### PR DESCRIPTION
To test the open Pull Request to support Arch Linux in osbuild, pacman
is required on the host.