### PR TITLE
Add `libxcrypt-compat` to unbreak google cloud tool

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -319,6 +319,7 @@ target "virtual-cloud-tools" {
         args = {
                 OSB_DNF_PACKAGES = join(",", [
                         "google-cloud-sdk",
+                        "libxcrypt-compat", 
                         "azure-cli",
                         "awscli",
                 ]),


### PR DESCRIPTION
The google cloud tool apparently uses a bundled python3, which needs `libcrypt.so.1` but does not declare that as dependency. Since we do not install `libxcrypt-compat` by default, it is broken:

    /usr/lib64/google-cloud-sdk/platform/bundledpythonunix/bin/python3:
    error while loading shared libraries: libcrypt.so.1:
    cannot open shared object file: No such file or directory

Install `libxcrypt-compat` for now to fix it.