### PR TITLE
Add skopeo to the CI container

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -226,6 +226,7 @@ target "virtual-osbuild-ci" {
                         "rpm-build",
                         "rpm-ostree",
                         "rpmdevtools",
+                        "skopeo",
                         "systemd",
                         "systemd-container",
                         "tar",


### PR DESCRIPTION
The work on container support (see
https://github.com/osbuild/osbuild/pull/952) needs skopeo to download
containers.