### PR TITLE
cloud-tools: install openssh-clients

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -305,6 +305,7 @@ target "virtual-cloud-tools" {
                         "libxcrypt-compat", 
                         "azure-cli",
                         "awscli",
+                        "openssh-clients",
                 ]),
         }
         dockerfile = "src/images/cloud-tools.Dockerfile"


### PR DESCRIPTION
Install SSH client in the `cloud-tools` container to allow `gcloud
compute ssh` command, which is just a thin wrapper of the SSH client.

Signed-off-by: Tomas Hozza <thozza@redhat.com>