### PR TITLE
image/rpmrepo-ci: add python3-requests

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -347,6 +347,7 @@ target "virtual-rpmrepo-ci" {
                         "python3-botocore",
                         "python3-pylint",
                         "python3-pytest",
+                        "python3-requests",
                 ]),
         }
         dockerfile = "src/images/rpmrepo-ci.Dockerfile"


### PR DESCRIPTION
Add the requests library to the rpmrepo-ci image. This will be used by the repository-configuration validation PR.