### PR TITLE
containers/ghci-osbuild: include autopep8

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -206,6 +206,7 @@ target "virtual-osbuild-ci" {
                         "policycoreutils",
                         "pylint",
                         "python-rpm-macros",
+                        "python3-autopep8",
                         "python3-boto3",
                         "python3-botocore",
                         "python3-docutils",


### PR DESCRIPTION
Will be used to check source code formatting.