### PR TITLE
containers/ghci-osbuild: include isort

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -212,6 +212,7 @@ target "virtual-osbuild-ci" {
                         "python3-docutils",
                         "python3-devel",
                         "python3-iniparse",
+                        "python3-isort",
                         "python3-jsonschema",
                         "python3-mako",
                         "python3-pylint",


### PR DESCRIPTION
Will be used to check source code formatting.