### PR TITLE
images/osbuild-ci: disable git-safe-dir

### DIFF
--- a/src/images/osbuild-ci.Dockerfile
+++ b/src/images/osbuild-ci.Dockerfile
@@ -38,6 +38,13 @@ COPY            src/scripts/osbuild-ci.sh .
 RUN             rm -rf /osb/src
 
 #
+# Allow cross-UID git access. Git users must be careful not to invoke git from
+# within untrusted directory-paths.
+#
+
+RUN             git config --global --add safe.directory '*'
+
+#
 # Rebuild from scratch to drop all intermediate layers and keep the final image
 # as small as possible. Then setup the entrypoint.
 #


### PR DESCRIPTION
Git recently stopped supporting running `git` from within a directory-path that contains `.git/` ancestors with a different UID. This is to prevent malicious users from injecting code into git-hooks of a different user.

We disable this security measure for the CI, since we do not invoke git from untrusted paths.

CC @gicmo @supakeen (This should fix the git-safe-directory issues of the new CI containers)