### PR TITLE
Update to node 16

### DIFF
--- a/src/actions/ghci-osbuild/action.yml
+++ b/src/actions/ghci-osbuild/action.yml
@@ -47,5 +47,5 @@ inputs:
       This uses `github.token` by default.
     default: ${{ github.token }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/src/actions/netwait/action.yml
+++ b/src/actions/netwait/action.yml
@@ -27,5 +27,5 @@ inputs:
       This uses `16` by default.
     default: 16
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/src/actions/privdocker/action.yml
+++ b/src/actions/privdocker/action.yml
@@ -26,5 +26,5 @@ inputs:
       This prints "Nothing to do." by default.
     default: 'echo "Nothing to do."'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Version 12 will be deprecated summer 2022, see [1].

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/