### PR TITLE
osbuild-ci: add pip

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -224,6 +224,7 @@ target "virtual-osbuild-ci" {
                         "python3-jsonschema",
                         "python3-mako",
                         "python3-mypy",
+                        "python3-pip",
                         "python3-pylint",
                         "python3-pytest",
                         "python3-pytest-cov",


### PR DESCRIPTION
This is related to: https://github.com/osbuild/osbuild/pull/1133 where we will need to install `osbuild` for the new module-is-executable things to work.