### PR TITLE
Add dosfstools to osbuild-ci container

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -234,6 +234,7 @@ target "virtual-osbuild-ci" {
                         "curl",
                         "dnf",
                         "dnf-plugins-core",
+                        "dosfstools",
                         "e2fsprogs",
                         "findutils",
                         "git",


### PR DESCRIPTION
This is needed for the `mkfs.fat` command.

This is needed for https://github.com/osbuild/osbuild/pull/1282