### PR TITLE
osbuild: Add python3-librepo

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -263,6 +263,7 @@ target "virtual-osbuild-ci" {
                         "python3-iniparse",
                         "python3-isort",
                         "python3-jsonschema",
+                        "python3-librepo",
                         "python3-mako",
                         "python3-mypy",
                         "python3-pip",


### PR DESCRIPTION
This is needed for testing of org.osbuild.librepo source: https://github.com/osbuild/osbuild/pull/1304