### PR TITLE
osbuild: Add btrfs-progs

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -228,6 +228,7 @@ target "virtual-osbuild-ci" {
         args = {
                 OSB_DNF_PACKAGES = join(",", [
                         "bash",
+                        "btrfs-progs",
                         "bubblewrap",
                         "coreutils",
                         "cryptsetup",


### PR DESCRIPTION
We will soon have tests for btrfs that require btrfs(1) available. Let's add it to the list.