### PR TITLE
docker-bake.hcl: add erofs-utils to the container

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -237,6 +237,7 @@ target "virtual-osbuild-ci" {
                         "dnf-plugins-core",
                         "dosfstools",
                         "e2fsprogs",
+                        "erofs-utils",
                         "findutils",
                         "git",
                         "glibc",


### PR DESCRIPTION
The erofs-utils package will be used by the new test for the `org.osbuilder.erofs` stage proposed in
https://github.com/osbuild/osbuild/pull/1437