### PR TITLE
Add osbuild-ci images based on c8s and c9s

### DIFF
--- a/src/config/google-cloud-sdk.repo
+++ b/src/config/google-cloud-sdk.repo
@@ -3,6 +3,6 @@ name=Google Cloud SDK
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/src/images/osbuild-ci-cstream.Dockerfile
+++ b/src/images/osbuild-ci-cstream.Dockerfile
@@ -1,0 +1,63 @@
+#
+# osbuild-ci - OSBuild CI Images
+#
+# This image provides the OS environment for the osbuild continuous integration
+# on GitHub Actions. It is based on CentOS Stream and includes all the required
+# packages and utilities for running unit-tests.
+#
+# Arguments:
+#
+#   * OSB_FROM="quay.io/centos/centos:stream9"
+#       This controls the host container used as base for the CI image.
+#
+#   * OSB_DNF_PACKAGES=""
+#       Specify the packages to install into the container. Separate packages
+#       by comma. By default, no package is pulled in.
+#
+#   * OSB_DNF_GROUPS=""
+#       Specify the package groups to install into the container. Separate
+#       groups by comma. By default, no group is pulled in.
+#
+#   * OSB_PIP_PACKAGES=""
+#       Specify the packages to install into the container using pip. Separate
+#       packages by comma. By default, no packages are installed.
+#
+
+ARG             OSB_FROM="quay.io/centos/centos:stream9"
+FROM            "${OSB_FROM}" AS target
+
+#
+# Import our build sources and prepare the target environment. When finished,
+# we drop the build sources again, to keep the target image small.
+#
+
+WORKDIR         /osb
+COPY            src src
+
+ARG             OSB_DNF_PACKAGES=""
+ARG             OSB_DNF_GROUPS=""
+ARG             OSB_PIP_PACKAGES=""
+ARG             OSB_DNF_ALLOW_ERASING=""
+RUN             ./src/scripts/dnf.sh "${OSB_DNF_PACKAGES}" "${OSB_DNF_GROUPS}" ${OSB_DNF_ALLOW_ERASING}
+RUN             ./src/scripts/pip.sh "${OSB_PIP_PACKAGES}"
+COPY            src/scripts/osbuild-ci.sh .
+
+RUN             rm -rf /osb/src
+
+#
+# Allow cross-UID git access. Git users must be careful not to invoke git from
+# within untrusted directory-paths.
+#
+
+RUN             git config --global --add safe.directory '*'
+
+#
+# Rebuild from scratch to drop all intermediate layers and keep the final image
+# as small as possible. Then setup the entrypoint.
+#
+
+FROM            scratch
+COPY            --from=target . .
+
+WORKDIR         /osb/workdir
+ENTRYPOINT      ["/osb/osbuild-ci.sh"]

--- a/src/scripts/install-oci-cli.sh
+++ b/src/scripts/install-oci-cli.sh
@@ -2,4 +2,18 @@
 
 set -eox pipefail
 
-bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- --accept-all-defaults
+# temporary filename for the script
+INSTALL_SCRIPT_PATH="mktemp"
+
+curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh --output "${INSTALL_SCRIPT_PATH}"
+
+# install python3.11 if the python3 version is 3.12 or newer
+# https://github.com/oracle/oci-cli/issues/742
+if [[ $(python3 -c "import sys; too_new = sys.version_info >= (3, 12, 0); print(1 if too_new else 0)") -eq 1 ]]; then
+    sudo dnf install -y python3.11
+    sudo dnf clean all
+    sed -i 's/for try_python_exe in /&python3.11 /' "${INSTALL_SCRIPT_PATH}"
+fi
+
+
+bash "${INSTALL_SCRIPT_PATH}" --accept-all-defaults

--- a/src/scripts/pip.sh
+++ b/src/scripts/pip.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#
+# This script is a pip package install helper for container images. It takes
+# packages as argument and then installs them via `pip3`.
+#
+
+set -eox pipefail
+
+OSB_IFS=$IFS
+
+#
+# Parse command-line arguments into local variables. We accept:
+#   @1: Comma-separated list of packages to install.
+#
+
+if (( $# > 0 )) ; then
+        IFS=',' read -r -a PIP_PACKAGES <<< "$1"
+        IFS=$OSB_IFS
+fi
+if (( $# > 1 )) ; then
+        echo >&2 "ERROR: invalid number of arguments"
+        exit 1
+fi
+
+#
+# Install the specified packages.
+#
+
+if (( ${#PIP_PACKAGES[@]} )) ; then
+        pip3 install --upgrade "${PIP_PACKAGES[@]}"
+fi


### PR DESCRIPTION
Add two new variants of the osbuild-ci image based on c8s and c9s.

**The intention is to use these images to run osbuild unit tests in the upstream, to catch any RHEL incompatibilities early as possible.**

CentOS Stream is lacking some packages. Install all of the unavailable python packages using pip and also pytest on cXs images. The reason is for not installing pytest from cXs repositories is to get the latest version of it to not have to deal with lack of features on older releases.

In addition, the cXs base images contain minimal variants of some packages, which we want to install into them. To resolve the conflicts, allow erasing of packages during package installation.

The intention is that these cXs images will be used mostly to run the unit tests. The Fedora image should be used for all the additional testing (such as pylint, mypy, isort, ...), including unit tests.

In additon:

- extend the `scr/scripts/dnf.sh` to optionally allow package erasing on installation (needed for cXs images.
- disable repo GPG check for Google Cloud SDK repo, since it is failing and Google has it disabled as well :man_facepalming: 