### PR TITLE
Use 'osbuild-ci' name for the Fedora image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -320,7 +320,7 @@ target "osbuild-ci-latest" {
                 "virtual-osbuild-ci-base",
         ]
         tags = concat(
-                mirror("osbuild-ci-fedora", "latest", "", OSB_UNIQUEID),
+                mirror("osbuild-ci", "latest", "", OSB_UNIQUEID),
         )
 }
 


### PR DESCRIPTION
When I was adding the c8s and c9s variants of the osbuild-ci image, I first added the '-fedora' suffix to the 'osbuild-ci' image which is based on Fedora. However, I later reverted it back, basically to keep the current version of osbuild CI working without any change. Unfortunately, it turns out that I missed to revert one case of this change. Fixing it now.