### PR TITLE
osbuild: add podman

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -260,6 +260,7 @@ target "virtual-osbuild-ci-base" {
                         "nbd-cli",
                         "ostree",
                         "pacman",
+                        "podman",
                         "policycoreutils",
                         "pylint",
                         "python-rpm-macros",


### PR DESCRIPTION
The stage tests for https://github.com/osbuild/osbuild/pull/1547 require podman inside the container.

[edit: setting back to draft, there are many issues with installing podman inside the container as shown in https://github.com/osbuild/osbuild/pull/1547]