### PR TITLE
Images: Add fuse-overlayfs to cXs CI images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -387,6 +387,7 @@ target "virtual-osbuild-ci-cXs" {
                         "tar",
                         //"tox",                 // not available in cXs
                         "util-linux",
+                        "fuse-overlayfs",
                 ]),
                 OSB_PIP_PACKAGES = join(",", [
                         "autopep8",


### PR DESCRIPTION
test_skopeo_with_localstorage started to fail on c8s. Solution is to install missing fuse-overlayfs package.