### PR TITLE
osbuild: add python3-libdnf5

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -278,6 +278,7 @@ target "virtual-osbuild-ci-base" {
                         "python3-isort",
                         "python3-jsonschema",
                         "python3-librepo",
+                        "python3-libdnf5",
                         "python3-mako",
                         "python3-mypy",
                         "python3-pip",


### PR DESCRIPTION
Add the libdnf5 python bindings for testing osbuild-depsolve-dnf5 in osbuild CI.