### PR TITLE
osbuild: add `podman` for tests like `test_container_deploy.py`

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -260,6 +260,7 @@ target "virtual-osbuild-ci-base" {
                         "nbd-cli",
                         "ostree",
                         "pacman",
+                        "podman",
                         "policycoreutils",
                         "pylint",
                         "python-rpm-macros",


### PR DESCRIPTION
It was discovered that the dev container does not contain podman so many of our podman tests are skipped. This commit fixes this.

See also
https://github.com/osbuild/osbuild/pull/1752#discussion_r1578294358 https://github.com/osbuild/osbuild/pull/1755

Thanks to Florian Schüller