### PR TITLE
Images: Add c10s based image to CI images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -234,6 +234,7 @@ group "all-osbuild-ci" {
                 "osbuild-ci-latest",
                 "osbuild-ci-c8s-latest",
                 "osbuild-ci-c9s-latest",
+                "osbuild-ci-c10s-latest",
         ]
 }
 
@@ -433,6 +434,18 @@ target "osbuild-ci-c9s-latest" {
         ]
         tags = concat(
                 mirror("osbuild-ci-c9s", "latest", "", OSB_UNIQUEID),
+        )
+}
+
+target "osbuild-ci-c10s-latest" {
+        args = {
+                OSB_FROM = "quay.io/centos/centos:stream10-development",
+        }
+        inherits = [
+                "virtual-osbuild-ci-cXs",
+        ]
+        tags = concat(
+                mirror("osbuild-ci-c10s", "latest", "", OSB_UNIQUEID),
         )
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -232,7 +232,6 @@ target "nfsd-latest" {
 group "all-osbuild-ci" {
         targets = [
                 "osbuild-ci-latest",
-                "osbuild-ci-c8s-latest",
                 "osbuild-ci-c9s-latest",
                 "osbuild-ci-c10s-latest",
         ]
@@ -411,18 +410,6 @@ target "virtual-osbuild-ci-cXs" {
         inherits = [
                 "virtual-osbuild-ci-base",
         ]
-}
-
-target "osbuild-ci-c8s-latest" {
-        args = {
-                OSB_FROM = "quay.io/centos/centos:stream8",
-        }
-        inherits = [
-                "virtual-osbuild-ci-cXs",
-        ]
-        tags = concat(
-                mirror("osbuild-ci-c8s", "latest", "", OSB_UNIQUEID),
-        )
 }
 
 target "osbuild-ci-c9s-latest" {


### PR DESCRIPTION
Centos 10 needs to be used to run daily CI tests
together with c8s and c10s. This commit adds c10s image definition to existing CI images.