### PR TITLE
osbuild-ci: install python3.13 interpreter

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -270,6 +270,7 @@ python3.8
 python3.9
 python3.10
 python3.12
+python3.13
 python3-autopep8
 python3-boto3
 python3-botocore
@@ -350,6 +351,7 @@ python3.8
 python3.9
 python3.10
 python3.12
+python3.13
 python3-autopep8
 python3-boto3
 python3-botocore


### PR DESCRIPTION
This will fix the problem that the osbuild-ci built using the latest Fedora does not include the default Python3 version that comes with it (3.13).