### PR TITLE
images/rpmrepo-snapshot: pin base image to fedora 40

### DIFF
--- a/src/images/rpmrepo-snapshot.Dockerfile
+++ b/src/images/rpmrepo-snapshot.Dockerfile
@@ -18,7 +18,7 @@
 #       groups by comma. By default, no group is pulled in.
 #
 
-ARG             OSB_FROM="docker.io/library/fedora:latest"
+ARG             OSB_FROM="docker.io/library/fedora:40"
 FROM            "${OSB_FROM}" AS target
 
 #


### PR DESCRIPTION
Fedora 41 has dnf5, which doesn't support the reposync plugin yet.