### PR TITLE
docker-bake: f40 rpmrepo-snapshot 

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -580,7 +580,7 @@ target "virtual-rpmrepo-snapshot" {
 
 target "rpmrepo-snapshot-latest" {
         args = {
-                OSB_FROM = "docker.io/library/fedora:latest",
+                OSB_FROM = "docker.io/library/fedora:40",
         }
         inherits = [
                 "virtual-rpmrepo-snapshot",

--- a/src/images/rpmrepo-snapshot.Dockerfile
+++ b/src/images/rpmrepo-snapshot.Dockerfile
@@ -18,7 +18,7 @@
 #       groups by comma. By default, no group is pulled in.
 #
 
-ARG             OSB_FROM="docker.io/library/fedora:40"
+ARG             OSB_FROM="docker.io/library/fedora:latest"
 FROM            "${OSB_FROM}" AS target
 
 #


### PR DESCRIPTION


Fedora 41 has dnf5, which doesn't support the reposync plugin yet.

The previous PR changed the container version used by default if not explicitly specified. However, docker-bake.hcl specifies the container explicitly, so we needed to change it there.
