### PR TITLE
docker-bake: add `grub2-tools` for osbuild PR#1946

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -253,6 +253,7 @@ erofs-utils
 findutils
 git
 glibc
+grub2-tools
 iproute
 lvm2
 make


### PR DESCRIPTION
This commit adds the missing `grub2-tools` that is required in https://github.com/osbuild/osbuild/pull/1946