### PR TITLE
osbuild-ci: install grub2-pc-modules

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -253,6 +253,7 @@ erofs-utils
 findutils
 git
 glibc
+grub2-pc-modules
 grub2-tools
 iproute
 lvm2


### PR DESCRIPTION
It turned out, that installing grub2-tools is not enough to make 'org.osbuild.grub2.inst' tests run in osbuild. Until now, the test would be skipped, because the `osbuild-ci` image was never updated in the osbuild repository.

See https://github.com/osbuild/osbuild/actions/runs/12834514251/job/35791994053#step:3:274
```
...
stages/test/test_grub2_inst.py::test_grub2_partition SKIPPED (cannot...) [ 18%]
stages/test/test_grub2_inst.py::test_grub2_iso9660 SKIPPED (cannot f...) [ 18%]
...
```

And failures after updating the `osbuild-ci` image https://github.com/osbuild/osbuild/actions/runs/12812586711/job/35724614320?pr=1981#step:3:1244
```
...
/usr/lib64/python3.6/subprocess.py:438: CalledProcessError
----------------------------- Captured stdout call -----------------------------
grub2-mkimage (GRUB) 2.12
prefix: (,gpt1)/boot/
----------------------------- Captured stderr call -----------------------------
grub2-mkimage: error: cannot open `/usr/lib/grub/i386-pc/moddep.lst': No such file or directory.
______________________________ test_grub2_iso9660 ______________________________
...
```