### PR TITLE
Revert "docker-bake.hcl: base rpmrepo-snapshot on fedora 40"

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -586,7 +586,7 @@ target "virtual-rpmrepo-snapshot" {
 
 target "rpmrepo-snapshot-latest" {
         args = {
-                OSB_FROM = "docker.io/library/fedora:40",
+                OSB_FROM = "docker.io/library/fedora:latest",
         }
         inherits = [
                 "virtual-rpmrepo-snapshot",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -268,9 +268,7 @@ policycoreutils
 pylint
 python-rpm-macros
 python3.6
-python3.8
 python3.9
-python3.10
 python3.12
 python3.13
 python3-autopep8
@@ -350,10 +348,7 @@ nbd-cli
 pacman
 pylint
 python3.6
-python3.7
-python3.8
 python3.9
-python3.10
 python3.12
 python3.13
 python3-autopep8


### PR DESCRIPTION
This reverts commit 108122e9af0f298dcb344b47552b3c63b4164615.

DNF5 now has reposync plugin.