### PR TITLE
Rebuild and deploy all images on schedule and notify osbuild/osbuild

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -134,3 +134,22 @@ jobs:
         IMG_TARGET: ${{ matrix.image }}
       run: make bake
 
+  #
+  # Notify Downstream
+  #
+  # After all images are successfully deployed, trigger a workflow in the
+  # osbuild/osbuild repository to notify it of the updated images.
+  #
+  notify:
+    name: "Notify osbuild/osbuild"
+    runs-on: ubuntu-latest
+    needs: [config, ci]
+    if: ${{ needs.config.outputs.deploy == 'yes' }}
+    steps:
+    - name: "Trigger osbuild/osbuild workflow"
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        repository: osbuild/osbuild
+        event-type: osbuild-ci-images-updated
+        client-payload: '{"unique_id": "${{ needs.config.outputs.now }}"}'

--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -14,6 +14,9 @@ name: "CI for Image Builds"
 on:
   pull_request:
   push:
+  schedule:
+    # Run every 2 weeks (1st and 15th of each month) at midnight UTC
+    - cron: '0 0 1,15 * *'
   workflow_dispatch:
     inputs:
       target:
@@ -54,6 +57,8 @@ jobs:
         if [[ "${CTX_GITHUB_EVENT_NAME}" = "workflow_dispatch" ]] ; then
           IMG_DEPLOY="yes"
           IMG_TARGET=${CTX_GITHUB_EVENT_INPUTS_TARGET}
+        elif [[ "${CTX_GITHUB_EVENT_NAME}" = "schedule" ]] ; then
+          IMG_DEPLOY="yes"
         fi
 
         echo "deploy=${IMG_DEPLOY}" >>$GITHUB_OUTPUT

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -403,6 +403,7 @@ target "virtual-osbuild-ci-cXs" {
                         "tox",
                 ]),
                 OSB_DNF_ALLOW_ERASING = 1,
+                OSB_DNF_ENABLE_REPOS = "crb",
         }
         dockerfile = "src/images/osbuild-ci.Dockerfile"
         inherits = [

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -249,21 +249,27 @@ variable "BASE_PACKAGES" {
     default = <<EOF
 bash
 btrfs-progs
+btrfs-progs-devel
 bubblewrap
 coreutils
 cryptsetup
 curl
+device-mapper-devel
 dnf
 dnf-plugins-core
 dosfstools
 e2fsprogs
 erofs-utils
 findutils
+gcc
 git
 glibc
+go
+gpgme-devel
 grub2-pc-modules
 grub2-tools
 iproute
+jq
 lvm2
 make
 nbd
@@ -350,6 +356,7 @@ target "osbuild-ci-latest" {
 variable "CENTOS_REMOVED_PACKAGES" {
     default = <<EOF
 btrfs-progs
+btrfs-progs-devel
 erofs-utils
 nbd
 nbd-cli

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -237,6 +237,14 @@ group "all-osbuild-ci" {
         ]
 }
 
+
+/*
+ * Installed python versions
+ * 3.6 -> RH8
+ * 3.9 -> RH 9 (c9s)
+ * 3.12 -> RH 10 (c10s)
+ * 3.14 -> Latest stable Fedora (43)
+ */
 variable "BASE_PACKAGES" {
     default = <<EOF
 bash
@@ -270,7 +278,6 @@ python-rpm-macros
 python3.6
 python3.9
 python3.12
-python3.13
 python3.14
 python3-autopep8
 python3-boto3
@@ -351,7 +358,6 @@ pylint
 python3.6
 python3.9
 python3.12
-python3.13
 python3.14
 python3-autopep8
 python3-boto3

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -430,7 +430,7 @@ target "osbuild-ci-c10s-latest" {
         ]
         args = {
                 // DNF package list needs no changes so it is inherited
-                OSB_FROM = "quay.io/centos/centos:stream10-development",
+                OSB_FROM = "quay.io/centos/centos:stream10",
                 // Allow DNF to downgrade some packages in the container, otherwise it will fail
                 OSB_DNF_NOBEST = 1,
         }

--- a/src/images/osbuild-ci.Dockerfile
+++ b/src/images/osbuild-ci.Dockerfile
@@ -22,6 +22,11 @@
 #       Specify the packages to install into the container using pip. Separate
 #       packages by comma. By default, no packages are installed.
 #
+#   * OSB_DNF_ENABLE_REPOS=""
+#       Specify additional repositories to enable when installing packages.
+#       Separate repository IDs by comma. By default, no additional repos
+#       are enabled.
+#
 
 ARG             OSB_FROM="docker.io/library/fedora:latest"
 FROM            "${OSB_FROM}" AS target
@@ -39,7 +44,8 @@ ARG             OSB_DNF_GROUPS=""
 ARG             OSB_PIP_PACKAGES=""
 ARG             OSB_DNF_ALLOW_ERASING="0"
 ARG             OSB_DNF_NOBEST="0"
-RUN             ./src/scripts/dnf.sh "${OSB_DNF_PACKAGES}" "${OSB_DNF_GROUPS}" "${OSB_DNF_ALLOW_ERASING}" "${OSB_DNF_NOBEST}"
+ARG             OSB_DNF_ENABLE_REPOS=""
+RUN             ./src/scripts/dnf.sh "${OSB_DNF_PACKAGES}" "${OSB_DNF_GROUPS}" "${OSB_DNF_ALLOW_ERASING}" "${OSB_DNF_NOBEST}" "${OSB_DNF_ENABLE_REPOS}"
 RUN             ./src/scripts/pip.sh "${OSB_PIP_PACKAGES}"
 COPY            src/scripts/osbuild-ci.sh .
 

--- a/src/scripts/dnf.sh
+++ b/src/scripts/dnf.sh
@@ -16,6 +16,9 @@ OSB_IFS=$IFS
 #   @2: Comma-separated list of comp-groups to install.
 #   @3: 0 or 1 to enable or disable --allowerasing when installing packages.
 #       Disabled by default. (optional)
+#   @4: 0 or 1 to enable or disable --nobest when installing packages.
+#       Disabled by default. (optional)
+#   @5: Comma-separated list of repository IDs to enable. (optional)
 #
 
 if (( $# > 0 )) ; then
@@ -36,8 +39,12 @@ if (( $# > 3 )) && [[ ! $4 =~ ^[01]$ ]] ; then
         echo >&2 "       only 0 or 1 are allowed"
         exit 1
 fi
-
 if (( $# > 4 )) ; then
+        IFS=',' read -r -a OSB_ENABLE_REPOS <<< "$5"
+        IFS=$OSB_IFS
+fi
+
+if (( $# > 5 )) ; then
         echo >&2 "ERROR: invalid number of arguments"
         exit 1
 fi
@@ -70,6 +77,10 @@ fi
 if [[ "$NOBEST" == 1 ]] ; then
         EXTRA_ARGS+=" --nobest"
 fi
+
+for repo in "${OSB_ENABLE_REPOS[@]}" ; do
+        EXTRA_ARGS+=" --enablerepo=$repo"
+done
 
 DNF_VERSION=$(rpm -q --whatprovides dnf --qf "%{VERSION}\n")
 POSITIONAL_OPS_DELIMITER="--"


### PR DESCRIPTION
- Update the package list installed in the osbuild-ci images to reflect the current needs for testing.
- Rebuild and deploy updated container images on schedule twice a week so that we don't forget to do it manually.
- Update osbuild-ci-c10s to use the stable base container instead of the `-development` one, which is no longer updated.
- Notify the osbuild/osbuild repository when new container images have been deployed so that it can run its own GHA to update the GHAs that use `osbuild-ci*` images.